### PR TITLE
We did pass all of the TCK tests on Red Hat Enterprise Linux Server 7…

### DIFF
--- a/EAP-8.0.0/jakarta-core-jdk11.adoc
+++ b/EAP-8.0.0/jakarta-core-jdk11.adoc
@@ -14,7 +14,7 @@ URL to product download page: http://www.redhat.com/en/technologies/jboss-middle
 
 Product Description: An implementation of the Jakarta EE 10 Core Profile Specification
 Java SE provider and Version tested with: OpenJDK 64-Bit Server VM (Red_Hat-11.0.19.0.7-1) (build 11.0.19+7-LTS, mixed mode)
-OS version: Red Hat Enterprise Linux Server 7.4 (Maipo)
+OS version: Red Hat Enterprise Linux release 9.3
 ----
 Specification Name, Version and download URL:
 https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE Core Profile, 10]

--- a/EAP-8.0.0/jakarta-core-jdk17.adoc
+++ b/EAP-8.0.0/jakarta-core-jdk17.adoc
@@ -14,7 +14,7 @@ URL to product download page: http://www.redhat.com/en/technologies/jboss-middle
 
 Product Description: An implementation of the Jakarta EE 10 Core Profile Specification
 Java SE provider and Version tested with: OpenJDK 64-Bit Server VM (Red_Hat-17.0.7.0.7-1.el7openjdkportable) (build 17.0.7+7-LTS, mixed mode, sharing)
-OS version: Red Hat Enterprise Linux Server 7.4 (Maipo)
+OS version: Red Hat Enterprise Linux release 9.3
 ----
 Specification Name, Version and download URL:
 https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE Core Profile, 10]

--- a/EAP-8.0.0/jakarta-full-platform-jdk11.adoc
+++ b/EAP-8.0.0/jakarta-full-platform-jdk11.adoc
@@ -18,7 +18,7 @@ URL to product download page: http://www.redhat.com/en/technologies/jboss-middle
 
 Product Description: An implementation of the Jakarta EE 10 Full Platform Specification
 Java SE provider and Version tested with:  OpenJDK 64-Bit Server VM (Red_Hat-11.0.19.0.7-1) (build 11.0.19+7-LTS, mixed mode)
-OS version: Red Hat Enterprise Linux Server 7.4 (Maipo)
+OS version: Red Hat Enterprise Linux release 9.3
 Database version:   Apache Derby Network Server 10.15.2.0
 Database JDBC Driver and version:  Apache Derby 10.15.2.0
 ----

--- a/EAP-8.0.0/jakarta-full-platform-jdk17.adoc
+++ b/EAP-8.0.0/jakarta-full-platform-jdk17.adoc
@@ -18,7 +18,7 @@ URL to product download page: http://www.redhat.com/en/technologies/jboss-middle
 
 Product Description: An implementation of the Jakarta EE 10 Full Platform Specification
 Java SE provider and Version tested with: OpenJDK 64-Bit Server VM (Red_Hat-17.0.7.0.7-1.el7openjdkportable) (build 17.0.7+7-LTS, mixed mode, sharing)
-OS version: Red Hat Enterprise Linux Server 7.4 (Maipo)
+OS version: Red Hat Enterprise Linux release 9.3
 Database version:   Apache Derby Network Server 10.15.2.0
 Database JDBC Driver and version:  Apache Derby 10.15.2.0
 ----

--- a/EAP-8.0.0/jakarta-web-profile-jdk11.adoc
+++ b/EAP-8.0.0/jakarta-web-profile-jdk11.adoc
@@ -18,7 +18,7 @@ URL to product download page: http://www.redhat.com/en/technologies/jboss-middle
 
 Product Description: An implementation of the Jakarta EE 10 Web Profile Specification
 Java SE provider and Version tested with:  OpenJDK 64-Bit Server VM (Red_Hat-11.0.19.0.7-1) (build 11.0.19+7-LTS, mixed mode)
-OS version: Red Hat Enterprise Linux Server 7.4 (Maipo)
+OS version: Red Hat Enterprise Linux release 9.3
 Database version:   Apache Derby Network Server 10.15.2.0
 Database JDBC Driver and version:  Apache Derby 10.15.2.0
 ----

--- a/EAP-8.0.0/jakarta-web-profile-jdk17.adoc
+++ b/EAP-8.0.0/jakarta-web-profile-jdk17.adoc
@@ -18,7 +18,7 @@ URL to product download page: http://www.redhat.com/en/technologies/jboss-middle
 
 Product Description: An implementation of the Jakarta EE 10 Web Profile Specification
 Java SE provider and Version tested with: OpenJDK 64-Bit Server VM (Red_Hat-17.0.7.0.7-1.el7openjdkportable) (build 17.0.7+7-LTS, mixed mode, sharing)
-OS version: Red Hat Enterprise Linux Server 7.4 (Maipo)
+OS version: Red Hat Enterprise Linux release 9.3
 Database version:   Apache Derby Network Server 10.15.2.0
 Database JDBC Driver and version:  Apache Derby 10.15.2.0
 ----


### PR DESCRIPTION
We did pass all of the TCK tests on Red Hat Enterprise Linux Server 7.4 and have now also passed all of the tests on Red Hat Enterprise Linux release 9.3.  We will continue to validate that all subsequent JBoss EAP 8 releases also pass (likely on Red Hat Enterprise Linux release 9.3 or newer).